### PR TITLE
Don't track who submitted a topic

### DIFF
--- a/app/index/route.js
+++ b/app/index/route.js
@@ -9,7 +9,6 @@ export default Ember.Route.extend({
     createNewTopic() {
       this.get('store').createRecord('topic', {
         description: this.get('controller.newTopic'),
-        submittedBy: this.get('session.currentUser'),
         submittedDate: new Date()
       }).save();
       this.set('controller.newTopic', '');

--- a/app/topic/model.js
+++ b/app/topic/model.js
@@ -7,7 +7,6 @@ export default DS.Model.extend({
   upvoters: DS.hasMany('user', { async: true }),
   volunteers: DS.hasMany('user', { async: true }),
 
-  submittedBy: DS.belongsTo('user', { async: true }),
   submittedDate: DS.attr('date'),
 
   upvoteCount: Ember.computed.readOnly('upvoters.length'),


### PR DESCRIPTION
I hadn't thought about the fact that people could easily see who submitted topics in the ember inspector even though I was advertising topic submission as anonymous.

This will close issue https://github.com/embernati/lightning/issues/10.

Upvoting/volunteering is not anonymous so that it can be toggled, but I will also not advertise that as being anonymous.  Only submitting topics will be considered anonymous and now it truly is!